### PR TITLE
Relax dependency version restrictions for httparty

### DIFF
--- a/lib/moodle_rb/version.rb
+++ b/lib/moodle_rb/version.rb
@@ -1,5 +1,5 @@
 module MoodleRb
-  VERSION = '1.0.4' unless defined?(self::VERSION)
+  VERSION = '1.0.5' unless defined?(self::VERSION)
 
   def self.version
     VERSION

--- a/moodle_rb.gemspec
+++ b/moodle_rb.gemspec
@@ -23,5 +23,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'webmock', '~> 1.0'
   spec.add_development_dependency 'vcr', '~> 2.9'
 
-  spec.add_dependency 'httparty', '~> 0.11.0'
+  spec.add_dependency 'httparty', '>= 0.11.0'
 end


### PR DESCRIPTION
By restricting the httparty version to “~>0.11.0” the gem ist
incompatible to other gems which require newer versions.

For example, I want to read users from moodle and add them to gitlab,
but the gitlab gem needs httparty version “>= 0.14.0”.