### PR TITLE
RTO-27047: [LMS course copy] Update Moodle gem to allow course copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,14 @@ Get course module
 moodle.courses.module(course_module_id)
 ```
 
+Copy one course to another
+```
+moodle.courses.core_course_import_course(
+  :from_course_id => from_course_id,
+  :to_course_id => to_course_id
+)
+```
+
 ### Categories
 
 Create a category

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Get course module
 moodle.courses.module(course_module_id)
 ```
 
-Copy one course to another
+Import course data from a course into another course
 ```
 moodle.courses.core_course_import_course(
   :from_course_id => from_course_id,

--- a/lib/moodle_rb/courses.rb
+++ b/lib/moodle_rb/courses.rb
@@ -160,5 +160,23 @@ module MoodleRb
       check_for_errors(response)
       response.parsed_response['cm']
     end
+
+    # required params:
+    # from_course_id: the id of the course we are importing from
+    # to_course_id:   the id of the course we are importing to
+    def core_course_import_course(params)
+      response = self.class.post(
+        '/webservice/rest/server.php',
+        {
+          :query => query_hash('core_course_import_course', token),
+          :body => {
+            :importfrom => params[:from_course_id],
+            :importto => params[:to_course_id]
+          }
+        }.merge(query_options)
+      )
+      check_for_errors(response)
+      response.code == 200 && response.parsed_response.nil?
+    end
   end
 end

--- a/lib/moodle_rb/version.rb
+++ b/lib/moodle_rb/version.rb
@@ -1,5 +1,5 @@
 module MoodleRb
-  VERSION = '2.1.0' unless defined?(self::VERSION)
+  VERSION = '2.1.5' unless defined?(self::VERSION)
 
   def self.version
     VERSION

--- a/spec/cassettes/MoodleRb_Courses/_core_course_import_course/when_using_invalid_token/.yml
+++ b/spec/cassettes/MoodleRb_Courses/_core_course_import_course/when_using_invalid_token/.yml
@@ -1,0 +1,55 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://localhost:8888/moodle28/webservice/rest/server.php?moodlewsrestformat=json&wsfunction=core_course_import_course&wstoken=
+    body:
+      encoding: UTF-8
+      string: importfrom=&importto=
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Accept-Ranges:
+      - none
+      Access-Control-Allow-Origin:
+      - "*"
+      Age:
+      - '0'
+      Cache-Control:
+      - private, must-revalidate, pre-check=0, post-check=0, max-age=0
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Feb 2023 02:46:46 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Moodle
+      X-Cache:
+      - MISS
+      X-Clacks-Overhead:
+      - GNU Terry Pratchett
+      X-Powered-By:
+      - Moodle Ninjas
+      Content-Length:
+      - '103'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"exception":"moodle_exception","errorcode":"invalidtoken","message":"Invalid
+        token - token not found"}'
+    http_version:
+  recorded_at: Mon, 13 Feb 2023 02:46:46 GMT
+recorded_with: VCR 2.9.3

--- a/spec/cassettes/MoodleRb_Courses/_core_course_import_course/when_using_valid_token/.yml
+++ b/spec/cassettes/MoodleRb_Courses/_core_course_import_course/when_using_valid_token/.yml
@@ -1,0 +1,54 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://localhost:8888/moodle28/webservice/rest/server.php?moodlewsrestformat=json&wsfunction=core_course_import_course&wstoken=60fc9c9415259404795094957e4ab32f
+    body:
+      encoding: UTF-8
+      string: importfrom=467&importto=468
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Accept-Ranges:
+      - none
+      Access-Control-Allow-Origin:
+      - "*"
+      Age:
+      - '0'
+      Cache-Control:
+      - private, must-revalidate, pre-check=0, post-check=0, max-age=0
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Feb 2023 02:46:43 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Moodle
+      X-Cache:
+      - MISS
+      X-Clacks-Overhead:
+      - GNU Terry Pratchett
+      X-Powered-By:
+      - Moodle Ninjas
+      Content-Length:
+      - '4'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: 'null'
+    http_version:
+  recorded_at: Mon, 13 Feb 2023 02:46:44 GMT
+recorded_with: VCR 2.9.3

--- a/spec/cassettes/MoodleRb_Courses/_core_course_import_course/when_using_valid_token/when_using_invalid_course_id/.yml
+++ b/spec/cassettes/MoodleRb_Courses/_core_course_import_course/when_using_valid_token/when_using_invalid_course_id/.yml
@@ -1,0 +1,55 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: http://localhost:8888/moodle28/webservice/rest/server.php?moodlewsrestformat=json&wsfunction=core_course_import_course&wstoken=60fc9c9415259404795094957e4ab32f
+    body:
+      encoding: UTF-8
+      string: importfrom=467&importto=-1
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Accept-Ranges:
+      - none
+      Access-Control-Allow-Origin:
+      - "*"
+      Age:
+      - '0'
+      Cache-Control:
+      - private, must-revalidate, pre-check=0, post-check=0, max-age=0
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 13 Feb 2023 02:46:45 GMT
+      Expires:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - Moodle
+      X-Cache:
+      - MISS
+      X-Clacks-Overhead:
+      - GNU Terry Pratchett
+      X-Powered-By:
+      - Moodle Ninjas
+      Content-Length:
+      - '117'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"exception":"moodle_exception","errorcode":"invalidcourseid","message":"You
+        are trying to use an invalid course ID"}'
+    http_version:
+  recorded_at: Mon, 13 Feb 2023 02:46:45 GMT
+recorded_with: VCR 2.9.3

--- a/spec/lib/moodle_rb/courses_spec.rb
+++ b/spec/lib/moodle_rb/courses_spec.rb
@@ -247,4 +247,48 @@ describe MoodleRb::Courses do
       end
     end
   end
+
+  describe '#core_course_import_course', :vcr => {
+    :match_requests_on => [:path], :record => :once
+  } do
+    context 'when using valid token' do
+      let(:params) do
+        {
+          :from_course_id => 467,
+          :to_course_id => 468
+        }
+      end
+      let(:result) { course_moodle_rb.core_course_import_course(params) }
+
+      specify do
+        expect(result).to eq true
+      end
+
+      context 'when using invalid course id' do
+        let(:params) do
+          {
+            :from_course_id => 467,
+            :to_course_id => -1
+          }
+        end
+
+        specify do
+          expect{ course_moodle_rb.core_course_import_course(params) }.to raise_error(
+            MoodleRb::MoodleError,
+            'You are trying to use an invalid course ID'
+          )
+        end
+      end
+    end
+
+    context 'when using invalid token' do
+      let(:token) { '' }
+      specify do
+        expect{ course_moodle_rb.core_course_import_course({}) }.to raise_error(
+          MoodleRb::MoodleError,
+          'Invalid token - token not found'
+        )
+      end
+    end
+  end
 end


### PR DESCRIPTION

Update the MoodleRB gem to include the core_course_import_course endpoint ([API documentation](https://readytech-test.moodlecloud.com/admin/webservice/documentation.php#)). This will allow us to copy the contents of a course in Moodle to another course.

The new call should be added to the [courses.rb](https://github.com/jobready/moodle-rb/blob/develop/lib/moodle_rb/courses.rb) file under a new def called copy that will take the following parameters: 

from_course_id -  the id of the course we are importing from

to_course_id -  the id of the course we are importing to

When this method is called the contents of the from course should be copied to the to course in Moodle.